### PR TITLE
Set minimum requied ruby version to 2.6.9

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== Not yet released
+
+* Drop support of ruby 2.5 or older versions as explicit.
+
 === 0.3.1 2021-12-30
 
 * The development of this repository has moved to https://github.com/ruby-jp/websocket-client-simple

--- a/websocket-client-simple.gemspec
+++ b/websocket-client-simple.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/ruby-jp/websocket-client-simple"
   spec.license       = "MIT"
+  spec.required_ruby_version = '>= 2.6.9'
 
   if spec.respond_to?(:metadata)
     spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Ruby 2.6 is now under the state of the security maintenance phase.
https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/
2.5 or older versions are EOL.