### PR TITLE
Don't give insecure defaults

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,7 @@
+=== Not yet released
+
+* Change TLS context defaults to system's default. The previous defaults were ssl_version=SSLv23 and verify_mode=VERIFY_NONE, which are insecure nowadays.
+
 === 0.4.0 2021-12-30
 
 * Drop support of ruby 2.5 or older versions as explicit.

--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -21,8 +21,8 @@ module WebSocket
                                   uri.port || (uri.scheme == 'wss' ? 443 : 80))
           if ['https', 'wss'].include? uri.scheme
             ctx = OpenSSL::SSL::SSLContext.new
-            ctx.ssl_version = options[:ssl_version] || 'SSLv23'
-            ctx.verify_mode = options[:verify_mode] || OpenSSL::SSL::VERIFY_NONE #use VERIFY_PEER for verification
+            ctx.ssl_version = options[:ssl_version] if options[:ssl_version]
+            ctx.verify_mode = options[:verify_mode] if options[:verify_mode]
             cert_store = OpenSSL::X509::Store.new
             cert_store.set_default_paths
             ctx.cert_store = cert_store


### PR DESCRIPTION
ssl_version and verify_mode should default to the Ruby's default.
`VERIFY_NONE` is insecure.

Note: This PR is a remake of https://github.com/shokai/websocket-client-simple/pull/18