### PR TITLE
rescue when OpenSSL::SSL::SSLError raised

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -76,6 +76,9 @@ module WebSocket
           rescue Errno::EPIPE => e
             @pipe_broken = true
             emit :__close, e
+          rescue OpenSSL::SSL::SSLError => e
+            @pipe_broken = true
+            emit :__close, e
           end
         end
 


### PR DESCRIPTION
It is necessary to detect the disconnection when an error occurs in SSL.