### PR TITLE
Allow passing cert store to client

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -23,10 +23,14 @@ module WebSocket
             ctx = OpenSSL::SSL::SSLContext.new
             ctx.ssl_version = options[:ssl_version] if options[:ssl_version]
             ctx.verify_mode = options[:verify_mode] if options[:verify_mode]
-            cert_store = OpenSSL::X509::Store.new
+            cert_store = options[:cert_store]
+            unless cert_store
+              cert_store = OpenSSL::X509::Store.new
+            end
             cert_store.set_default_paths
             ctx.cert_store = cert_store
             @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)
+            @socket.sync_close = true
             @socket.hostname = uri.host
             @socket.connect
           end

--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -23,10 +23,7 @@ module WebSocket
             ctx = OpenSSL::SSL::SSLContext.new
             ctx.ssl_version = options[:ssl_version] if options[:ssl_version]
             ctx.verify_mode = options[:verify_mode] if options[:verify_mode]
-            cert_store = options[:cert_store]
-            unless cert_store
-              cert_store = OpenSSL::X509::Store.new
-            end
+            cert_store = options[:cert_store] || OpenSSL::X509::Store.new
             cert_store.set_default_paths
             ctx.cert_store = cert_store
             @socket = ::OpenSSL::SSL::SSLSocket.new(@socket, ctx)


### PR DESCRIPTION
## What

* Allows passing [configured `cert_store`](https://github.com/DerekStride/stride-host/blob/d3ddc19c8b5b6b29e06ff4fa1d2c8c67fd1b5f9b/functions/scheduled-mc-scale-down/app.rb#L60) to the websocket client.
* Ensure underlying socket is closed when the `SSLSocket` is closed. See [`OpenSSL::SSL::SSLSocket#sync_close`](https://ruby-doc.org/stdlib-3.1.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLSocket.html).

