### PR TITLE
Make #open? safe to use when @handshake is nil

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -97,7 +97,7 @@ module WebSocket
         end
 
         def open?
-          @handshake.finished? and !@closed
+          @handshake&.finished? and !@closed
         end
 
         def closed?


### PR DESCRIPTION
I'm using `ws.open?` to check if the websocket is ready to send messages but it errors if the handshake hasn't occurred.
This should fix that.

https://github.com/ruby-jp/websocket-client-simple/blob/d5f968f4558add4df88659211a099a14f3bfdb99/lib/websocket-client-simple/client.rb#L99..L101