### PR TITLE
Expose thread so it can be joined

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -11,7 +11,7 @@ module WebSocket
 
       class Client
         include EventEmitter
-        attr_reader :url, :handshake
+        attr_reader :url, :handshake, :thread
 
         def connect(url, options={})
           return if @socket


### PR DESCRIPTION
I have a use case where I dont have to write anything to the websocket but just have to read from it.
Currently, I have to wait with

```
sleep(0.1) until ws.closed?
```

With the suggested change, it can be replaced with

```
ws.thread.join
```