### PR TITLE
Raise errors from WebSocket gem

### DIFF
--- a/lib/websocket-client-simple/client.rb
+++ b/lib/websocket-client-simple/client.rb
@@ -31,6 +31,7 @@ module WebSocket
             @socket.hostname = uri.host
             @socket.connect
           end
+          ::WebSocket.should_raise = true
           @handshake = ::WebSocket::Handshake::Client.new :url => url, :headers => options[:headers]
           @handshaked = false
           @pipe_broken = false


### PR DESCRIPTION
Without this, the library hangs forever when the server returns an HTTP error.
With this change, we get a `WebSocket::Error::Handshake::InvalidStatusCode` exception.