### PR TITLE
Add ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        ruby: ["3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+        ruby: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/websocket-client-simple.gemspec
+++ b/websocket-client-simple.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "websocket"
   spec.add_dependency "event_emitter"
+  spec.add_dependency "mutex_m"
+  spec.add_dependency "base64"
 end


### PR DESCRIPTION
mutex_m and base64 are moved to bundled gems from 3.4

see also https://stdgems.org/3.4.0/